### PR TITLE
Add @annotation support to apilint. r=snorp. 

### DIFF
--- a/apidoc/src/test/fake_root/org/mozilla/test/TestClass.java
+++ b/apidoc/src/test/fake_root/org/mozilla/test/TestClass.java
@@ -37,6 +37,11 @@ public class TestClass {
     protected TestClass (boolean arg) {}
     TestClass(int arg) {}
 
+    @Deprecated
+    public class DeprecatedClass {}
+    @SuppressWarnings("")
+    public class HiddenAnnotationClass {}
+
     public void testVoidMethod() {}
     public String testStringMethod() { return null; }
 
@@ -54,4 +59,18 @@ public class TestClass {
 
     protected void testProtectedMethod() {}
     void testPackageProtectedMethod() {}
+
+    @Deprecated
+    public void testAnnotation() {}
+    @Deprecated
+    public TestClass(float arg) {}
+    @Deprecated
+    public final static int TEST_DEPRECATED_CONST = 1;
+
+    @SuppressWarnings("")
+    public void testHiddenAnnotation() {}
+    @SuppressWarnings("")
+    public TestClass(int arg0, float arg1) {}
+    @SuppressWarnings("")
+    public final static int TEST_HIDDEN_ANNOTATION = 2;
 }

--- a/apidoc/src/test/resources/expected-doclet-output.txt
+++ b/apidoc/src/test/resources/expected-doclet-output.txt
@@ -5,6 +5,8 @@ package org.mozilla.test {
     ctor public TestClass(java.lang.String);
     ctor public TestClass(java.lang.String, int);
     ctor protected TestClass(boolean);
+    ctor @java.lang.Deprecated public TestClass(float);
+    ctor public TestClass(int, float);
     method public void testVoidMethod();
     method public java.lang.String testStringMethod();
     method public void testVoidMethodWithArg(java.lang.String);
@@ -16,11 +18,23 @@ package org.mozilla.test {
     method public void testVarArgsTwoArgs(int, int...);
     method public void testFinalArg(int);
     method protected void testProtectedMethod();
+    method @java.lang.Deprecated public void testAnnotation();
+    method public void testHiddenAnnotation();
     field public java.lang.String testFieldWithoutValue;
     field public java.lang.String testFieldWithValue;
     field public final java.lang.String testFinalField = "finalValue";
     field public static final java.lang.String testFinalStaticField = "finalStaticValue";
     field protected int testProtectedField;
+    field @java.lang.Deprecated public static final int TEST_DEPRECATED_CONST = 1;
+    field public static final int TEST_HIDDEN_ANNOTATION = 2;
+  }
+
+  @java.lang.Deprecated public class TestClass.DeprecatedClass {
+    ctor public DeprecatedClass();
+  }
+
+  public class TestClass.HiddenAnnotationClass {
+    ctor public HiddenAnnotationClass();
   }
 
   public abstract class TestClass.TestAbstractClass {

--- a/apilint/src/test/resources/apilint_test/test-annotation-add-class.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-add-class.after.txt
@@ -1,0 +1,5 @@
+package test {
+  @A @B @C @D @E @F @G public class TestClass {
+    ctor TestClass();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-add-class.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-add-class.before.txt
@@ -1,0 +1,5 @@
+package test {
+  @A @B @C @D @E @F public class TestClass {
+    ctor TestClass();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-add.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-add.after.txt
@@ -1,0 +1,5 @@
+package test {
+  public class TestClass {
+    method @A @B @C @D @E @F @G @H void testMethod();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-add.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-add.before.txt
@@ -1,0 +1,5 @@
+package test {
+  public class TestClass {
+    method @A @B @C @D @E @F @G void testMethod();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-remove-class.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-remove-class.after.txt
@@ -1,0 +1,5 @@
+package test {
+  @A @B @C @D @E @F public class TestClass {
+    ctor TestClass();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-remove-class.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-remove-class.before.txt
@@ -1,0 +1,5 @@
+package test {
+  @A @B @C @D @E @F @G public class TestClass {
+    ctor TestClass();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-remove-ctor.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-remove-ctor.after.txt
@@ -1,0 +1,5 @@
+package test {
+  public class TestClass {
+    ctor @A @B @C @D @E @F TestClass();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-remove-ctor.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-remove-ctor.before.txt
@@ -1,0 +1,5 @@
+package test {
+  public class TestClass {
+    ctor @A @B @C @D @E @F @G TestClass();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-remove.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-remove.after.txt
@@ -1,0 +1,5 @@
+package test {
+  public class TestClass {
+    method @A @B @C @D @E @F void testMethod();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-annotation-remove.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-annotation-remove.before.txt
@@ -1,0 +1,5 @@
+package test {
+  public class TestClass {
+    method @A @B @C @D @E @F @G void testMethod();
+  }
+}

--- a/apilint/src/test/resources/apilint_test/tests.py
+++ b/apilint/src/test/resources/apilint_test/tests.py
@@ -36,6 +36,18 @@
     "test": "test-method-renamed",
     "expected": "INCOMPATIBLE"
   },{
+    "test": "test-annotation-add",
+    "expected": "INCOMPATIBLE"
+  },{
+    "test": "test-annotation-remove",
+    "expected": "INCOMPATIBLE"
+  },{
+    "test": "test-annotation-remove-ctor",
+    "expected": "INCOMPATIBLE"
+  },{
+    "test": "test-annotation-remove-class",
+    "expected": "INCOMPATIBLE"
+  },{
     "test": "test-removed-final-modifier-class",
     "expected": "API_CHANGE"
   },{
@@ -46,6 +58,9 @@
     "expected": "API_CHANGE"
   },{
     "test": "test-method-moved-to-parent-class",
+    "expected": "API_CHANGE"
+  },{
+    "test": "test-annotation-add-class",
     "expected": "API_CHANGE"
   },{
     "test": "test-whitespace-change",


### PR DESCRIPTION
This patch adds support for `@annotations` in the API specification.

apilint will track certain, hard-coded, annotations and will error out if any
of those annotations are added or removed as that is assumed to be an
incompatible change.

This is the initial list of annotations that are tracked is as following:

- `java.lang.Deprecated`
- `android.support.annotation.AnyThread`
- `android.support.annotation.BinderThread`
- `android.support.annotation.MainThread`
- `android.support.annotation.UiThread`
- `android.support.annotation.WorkerThread`