### PR TITLE
Fixes #9: Fix @Annotation api generation.

### DIFF
--- a/apidoc-plugin/src/main/java/org/mozilla/doclet/ApiDoclet.java
+++ b/apidoc-plugin/src/main/java/org/mozilla/doclet/ApiDoclet.java
@@ -142,7 +142,8 @@ public class ApiDoclet {
         String classLine = annotationFragment(classDoc);
         classLine += classDoc.modifiers() + " ";
 
-        if (!classDoc.isInterface() && !classDoc.isEnum()) {
+        if (!classDoc.isInterface() && !classDoc.isEnum() &&
+                !classDoc.isAnnotationType()) {
             classLine += "class ";
         } else if (classDoc.isEnum()) {
             classLine += "enum ";

--- a/apidoc-plugin/src/test/fake_root/org/mozilla/test/TestClass.java
+++ b/apidoc-plugin/src/test/fake_root/org/mozilla/test/TestClass.java
@@ -81,6 +81,8 @@ public class TestClass {
     @SuppressWarnings("")
     public final static int TEST_HIDDEN_ANNOTATION = 2;
 
+    public @interface TestAnnotation {}
+
     public <T> void testTypeVariableUnbounded(T arg) {}
     public <T extends java.lang.Runnable> void testTypeVariableWithBounds(T arg) {}
     public <T extends java.lang.Runnable & java.lang.Cloneable> void testTypeVariableWithMultipleBounds(T arg) {}

--- a/apidoc-plugin/src/test/resources/expected-doclet-output.txt
+++ b/apidoc-plugin/src/test/resources/expected-doclet-output.txt
@@ -53,6 +53,9 @@ package org.mozilla.test {
     ctor public TestAbstractClass();
   }
 
+  public static interface TestClass.TestAnnotation implements java.lang.annotation.Annotation {
+  }
+
   public static final enum TestClass.TestEnum {
     method public static org.mozilla.test.TestClass.TestEnum[] values();
     method public static org.mozilla.test.TestClass.TestEnum valueOf(java.lang.String);


### PR DESCRIPTION
Before this commit @Annotations would be described as:

```
public static interface class Annotation implements java.lang.annotation.Annotation {
```

after this commit we remove the `class` part, producing:

```
public static interface Annotation implements java.lang.annotation.Annotation {
```