### PR TITLE
Fixes #14: Add publishing code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the following to your project:
 ```
 buildscript {
     dependencies {
-        classpath 'org.mozilla.android:apilint:0.1'
+        classpath 'org.mozilla.apilint:apilint:0.1'
     }
 }
 

--- a/apidoc-plugin/build.gradle
+++ b/apidoc-plugin/build.gradle
@@ -6,25 +6,35 @@ import org.mozilla.apilint.Config
 
 buildDir "${topobjdir}/apidoc-plugin"
 
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+    }
+}
+
 apply plugin: 'java'
 apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     implementation files("${System.properties['java.home']}/../lib/tools.jar")
 }
 
-def javadoc
+def javadocExecutable
 switch (JavaVersion.current()) {
     case JavaVersion.VERSION_1_7:
     case JavaVersion.VERSION_1_8:
-       javadoc = "${System.properties['java.home']}/../bin/javadoc"
+       javadocExecutable = "${System.properties['java.home']}/../bin/javadoc"
        break
 
     case JavaVersion.VERSION_1_9:
     case JavaVersion.VERSION_1_10:
     case JavaVersion.VERSION_11:
     case JavaVersion.VERSION_HIGHER:
-        javadoc = "${System.properties['java.home']}/bin/javadoc"
+        javadocExecutable = "${System.properties['java.home']}/bin/javadoc"
         break
 
     default:
@@ -34,8 +44,8 @@ switch (JavaVersion.current()) {
 task testApiDoclet(type: Exec) {
     workingDir '.'
     commandLine 'python', file('src/test/resources/apidoc_test.py'),
-        '--javadoc', javadoc,
-        '--doclet-jar', "${buildDir}/libs/apidoc-plugin.jar",
+        '--javadoc', javadocExecutable,
+        '--doclet-jar', "${buildDir}/libs/apidoc-plugin-${Config.API_DOC_VERSION}.jar",
         '--java-root', file('src/test/fake_root'),
         '--out-dir', "${buildDir}/tmp",
         '--expected', file('src/test/resources/expected-doclet-output.txt')
@@ -45,14 +55,52 @@ testApiDoclet.dependsOn jar
 
 test.dependsOn testApiDoclet
 
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier = 'sources'
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    from javadoc.destinationDir
+    classifier = 'javadoc'
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = 'org.mozilla.android'
+            groupId = Config.GROUP
             artifactId = 'apidoc-plugin'
             version = Config.API_DOC_VERSION
 
             from components.java
+            artifact sourcesJar
+            artifact javadocJar
         }
+    }
+}
+
+version = Config.API_DOC_VERSION
+group = Config.GROUP
+
+// Bintray
+Properties properties = new Properties()
+def localProperties = project.rootProject.file('local.properties')
+if (localProperties.exists()) {
+    properties.load(localProperties.newDataInputStream())
+}
+
+bintray {
+    user = properties.getProperty("bintray.user")
+    key = properties.getProperty("bintray.apikey")
+    publications = ['maven']
+    configurations = ['archives']
+    pkg {
+        repo = 'apidoc-plugin'
+        name = Config.GROUP
+        websiteUrl = 'https://github.com/mozilla-mobile/gradle-apilint'
+        vcsUrl = 'https://github.com/mozilla-mobile/gradle-apilint.git'
+        licenses = ["MPL-2.0"]
+        publish = true
+        publicDownloadNumbers = true
     }
 }

--- a/apilint/build.gradle
+++ b/apilint/build.gradle
@@ -3,10 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 plugins {
+    id 'com.gradle.plugin-publish' version '0.10.0'
     id 'java-gradle-plugin'
     id 'groovy'
     id 'maven-publish'
 }
+
+import org.mozilla.apilint.Config
+
+buildDir "${topobjdir}/apilint"
 
 sourceSets {
     main {
@@ -17,16 +22,28 @@ sourceSets {
     }
 }
 
-group 'org.mozilla.android'
+group Config.GROUP
 version '0.1'
-
-buildDir "${topobjdir}/apilint"
 
 gradlePlugin {
     plugins {
         apilint {
-            id = 'org.mozilla.apilint'
+            id = Config.GROUP
             implementationClass = 'org.mozilla.apilint.ApiLintPlugin'
+        }
+    }
+}
+
+pluginBundle {
+    website = 'https://github.com/mozilla-mobile/gradle-apilint'
+    vcsUrl = 'https://github.com/mozilla-mobile/gradle-apilint'
+
+    tags = ['api', 'lint', 'mozilla', 'plugin', 'compatibility']
+    description = 'Tracks the API of an Android library and helps maintain backward compatibility.'
+
+    plugins {
+        apilint {
+            displayName = 'API Lint plugin'
         }
     }
 }

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
@@ -30,7 +30,7 @@ class ApiCompatLintTask extends Javadoc {
                 project.file("${System.properties['java.home']}/lib/rt.jar")] + project.android.bootClasspath
 
         def config = project.configurations.create("apidoc-plugin")
-        project.dependencies.add("apidoc-plugin", "org.mozilla.android:apidoc-plugin:${Config.API_DOC_VERSION}")
+        project.dependencies.add("apidoc-plugin", "${Config.GROUP}:apidoc-plugin:${Config.API_DOC_VERSION}")
 
         options.doclet = "org.mozilla.doclet.ApiDoclet"
         options.docletpath = config.files.asType(List)

--- a/buildSrc/src/main/java/org/mozilla/apilint/Config.java
+++ b/buildSrc/src/main/java/org/mozilla/apilint/Config.java
@@ -6,4 +6,5 @@ package org.mozilla.apilint;
 
 public class Config {
     public final static String API_DOC_VERSION = "0.1";
+    public final static String GROUP = "org.mozilla.apilint";
 }


### PR DESCRIPTION
This commit integrates with BinTray to publish apidoc to jCenter and with
the Gradle Plugin repository to publish apilint to plugins.gradle.com.

It also changes the package to org.mozilla.apilint since org.mozilla.android is
used by something else.