### PR TITLE
Dependency

### DIFF
--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
@@ -21,6 +21,8 @@ class ApiCompatLintTask extends Javadoc {
     @InputFiles
     ArrayList<File> sourcePath
 
+    private final static String CONFIG_NAME = 'apidoc-plugin'
+
     @TaskAction
     @Override
     protected void generate() {
@@ -29,8 +31,13 @@ class ApiCompatLintTask extends Javadoc {
         options.bootClasspath = [
                 project.file("${System.properties['java.home']}/lib/rt.jar")] + project.android.bootClasspath
 
-        def config = project.configurations.create("apidoc-plugin")
-        project.dependencies.add("apidoc-plugin", "${Config.GROUP}:apidoc-plugin:${Config.API_DOC_VERSION}")
+        def config = project.configurations.findByName(CONFIG_NAME)
+
+        if (config == null) {
+            config = project.configurations.create(CONFIG_NAME)
+            project.dependencies.add(CONFIG_NAME,
+                    "${Config.GROUP}:apidoc-plugin:${Config.API_DOC_VERSION}")
+        }
 
         options.doclet = "org.mozilla.doclet.ApiDoclet"
         options.docletpath = config.files.asType(List)

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
@@ -47,6 +47,7 @@ class ApiLintPlugin implements Plugin<Project> {
 
             def apiLint = project.task("apiLint${name}", type: PythonExec) {
                 description = "Runs API lint checks for variant ${name}"
+                group = 'Verification'
                 workingDir '.'
                 scriptPath 'apilint.py'
                 args '--show-noticed'
@@ -90,6 +91,7 @@ class ApiLintPlugin implements Plugin<Project> {
 
             def apiUpdate = project.task("apiUpdateFile${name}", type: Copy) {
                 description = "Updates the API file from the local one for variant ${name}"
+                group = 'Verification'
                 from apiFile
                 into currentApiFile.getParent()
                 rename { apiFile.getName() }

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
@@ -56,6 +56,7 @@ class ApiLintPlugin implements Plugin<Project> {
             }
 
             apiLint.dependsOn apiGenerate
+            project.tasks.check.dependsOn apiLint
 
             def apiDiff = project.task("apiDiff${name}", type: Exec) {
                 description = "Prints the diff between the existing API and the local API."


### PR DESCRIPTION
Small fixes I found while integrating with `GeckoView`

* Fixes #21: Add apiLint to tasks.check.
* Add group to `apiLint` and `apiUpdate`.
This makes the tasks show up when calling `gradle tasks`.
* Fixes #20: Don't add apidoc-plugin dependency twice.
When running the `apiLint` command on multiple targets (e.g. on `debug` and
    `release`), `apiLint` fails because the dependency is added twice.