### PR TITLE
Closes #24: Generate json result file.

### DIFF
--- a/apilint/build.gradle
+++ b/apilint/build.gradle
@@ -50,7 +50,8 @@ pluginBundle {
 
 task testApiLint(type: Exec) {
     workingDir '.'
-    commandLine 'python', 'src/test/resources/apilint_test.py'
+    commandLine 'python', 'src/test/resources/apilint_test.py',
+        '--build-dir', buildDir
 }
 
 test.dependsOn testApiLint

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
@@ -53,6 +53,9 @@ class ApiLintPlugin implements Plugin<Project> {
                 args '--show-noticed'
                 args apiFile
                 args currentApiFile
+                args '--result-json'
+                args project.file(
+                        "${variant.javaCompile.destinationDir}/${extension.jsonResultFileName}")
             }
 
             apiLint.dependsOn apiGenerate

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPluginExtension.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPluginExtension.groovy
@@ -6,4 +6,5 @@ class ApiLintPluginExtension {
     String packageFilter = '.' // By default all packages are part of the api
     String apiOutputFileName = 'api.txt'
     String currentApiRelativeFilePath = 'api.txt'
+    String jsonResultFileName = 'apilint-result.json'
 }


### PR DESCRIPTION
This change adds a json file output with equivalent information as the command
line output. This file is intended to be consumed by automation tools.

This change also fixes a bug where the name of methods with annotations would
not be parsed correctly.