### PR TITLE
Closes #31: Add lint for fields-only classes.

### DIFF
--- a/apilint/src/test/resources/apilint_test.py
+++ b/apilint/src/test/resources/apilint_test.py
@@ -13,6 +13,7 @@ TEST_DIR = "src/test/resources/apilint_test/"
 ERROR_CODES = {
     'NO_CHANGE': 0,
     'API_CHANGE': 10,
+    'API_ERROR': 77,
     'INCOMPATIBLE': 131,
 }
 
@@ -43,6 +44,11 @@ for t in tests:
 
     error_code = sp.call(test)
 
+    with open(json_file) as f:
+        json_result = json.load(f)
+
+    print(json.dumps(json_result, indent=2))
+
     expected_error_code = ERROR_CODES[t["expected"]]
     if error_code != expected_error_code:
          print("The following test is expected to fail with {} "
@@ -51,12 +57,8 @@ for t in tests:
          print(" ".join(test))
          sys.exit(1)
 
-    with open(json_file) as f:
-        json_result = json.load(f)
-
-    print(json.dumps(json_result, indent=2))
-
-    assert len(json_result['failures']) == 0
+    if t['expected'] != 'API_ERROR':
+        assert len(json_result['failures']) == 0
 
     if t['expected'] == 'INCOMPATIBLE':
         assert len(json_result['compat_failures']) == 1
@@ -65,6 +67,11 @@ for t in tests:
 
     if t['expected'] == 'API_CHANGE':
         assert len(json_result['api_changes']) > 0
+
+    if t['expected'] == 'API_ERROR':
+        assert len(json_result['failures']) > 0
+        assert json_result['failure'] == True
+        assert json_result['failures'][0]['rule'] == t['rule']
 
     if t['expected'] == 'NO_CHANGE':
         assert len(json_result['api_changes']) == 0

--- a/apilint/src/test/resources/apilint_test/test-fields-only-class-final.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-fields-only-class-final.after.txt
@@ -1,0 +1,8 @@
+package test {
+  public final class FieldOnlyTest {
+    ctor protected FieldOnlyTest();
+    field public final int testField0;
+    field public final int testField1;
+    field public final int testField2;
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-fields-only-class-final.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-fields-only-class-final.before.txt
@@ -1,0 +1,2 @@
+package test {
+}

--- a/apilint/src/test/resources/apilint_test/test-fields-only-class.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-fields-only-class.after.txt
@@ -1,0 +1,7 @@
+package test {
+  public class TestFieldsOnly {
+    field public final int testField0;
+    field public final int testField1;
+    field public final int testField2;
+  }
+}

--- a/apilint/src/test/resources/apilint_test/test-fields-only-class.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-fields-only-class.before.txt
@@ -1,0 +1,2 @@
+package test {
+}

--- a/apilint/src/test/resources/apilint_test/tests.py
+++ b/apilint/src/test/resources/apilint_test/tests.py
@@ -69,6 +69,14 @@
     "test": "test-annotation-add-class",
     "expected": "API_CHANGE"
   },{
+    "test": "test-fields-only-class",
+    "expected": "API_ERROR",
+    "rule": "GV1"
+  },{
+    "test": "test-fields-only-class-final",
+    "expected": "API_ERROR",
+    "rule": "GV2"
+  },{
     "test": "test-whitespace-change",
     "expected": "NO_CHANGE"
   },{


### PR DESCRIPTION
This adds a lint to make sure that classes that only contain final fields have
a protected or public constructor in the API so that external clients can mock
these classes. It also checks that these classes are not final for test
subclassing.