### PR TITLE
Add support to enforce annotations

### DIFF
--- a/apidoc-plugin/src/test/fake_root/org/mozilla/test/TestClass.java
+++ b/apidoc-plugin/src/test/fake_root/org/mozilla/test/TestClass.java
@@ -36,6 +36,33 @@ public class TestClass {
     }
     public static class TestExtends extends TestInterfaceImpl {}
 
+    @Deprecated
+    public static class TestAnnotationBase {
+        private TestAnnotationBase();
+
+        @Deprecated
+        public void methodToOverride();
+    }
+
+    public static class TestAnnotationChildShouldHaveAnnotation extends TestAnnotationBase {
+        private TestAnnotationChildShouldHaveAnnotation();
+
+        @Override
+        public void methodToOverride();
+
+        // NOTE: Not @Override
+        public void methodToOverride(int overload);
+    }
+
+    @Deprecated
+    public static class TestAnnotationChildDuplicateAnnotation extends TestAnnotationBase {
+        private TestAnnotationChildDuplicateAnnotation();
+
+        @Override
+        @Deprecated
+        public void methodToOverride();
+    }
+
     public TestClass() {}
     public TestClass(String arg1) {}
     public TestClass(String arg1, int arg2) {}

--- a/apidoc-plugin/src/test/resources/expected-doclet-output.txt
+++ b/apidoc-plugin/src/test/resources/expected-doclet-output.txt
@@ -56,6 +56,19 @@ package org.mozilla.test {
   public static interface TestClass.TestAnnotation implements java.lang.annotation.Annotation {
   }
 
+  @java.lang.Deprecated public static class TestClass.TestAnnotationBase {
+    method @java.lang.Deprecated public void methodToOverride();
+  }
+
+  @java.lang.Deprecated public static class TestClass.TestAnnotationChildDuplicateAnnotation extends org.mozilla.test.TestClass.TestAnnotationBase {
+    method @java.lang.Deprecated public void methodToOverride();
+  }
+
+  @java.lang.Deprecated public static class TestClass.TestAnnotationChildShouldHaveAnnotation extends org.mozilla.test.TestClass.TestAnnotationBase {
+    method @java.lang.Deprecated public void methodToOverride();
+    method public void methodToOverride(int);
+  }
+
   public static final enum TestClass.TestEnum {
     method public static org.mozilla.test.TestClass.TestEnum valueOf(java.lang.String);
     method public static org.mozilla.test.TestClass.TestEnum[] values();

--- a/apilint/src/main/resources/apilint.py
+++ b/apilint/src/main/resources/apilint.py
@@ -523,6 +523,32 @@ def verify_final_fields_only_class(clazz):
     if "final" in clazz.split:
         error(clazz, None, "GV2", "Field-only classes should not be final for mocking.")
 
+def verify_threading_annotations(clazz):
+    THREADING_ANNOTATIONS = [
+        "android.support.annotation.MainThread",
+        "android.support.annotation.UiThread",
+        "android.support.annotation.WorkerThread",
+        "android.support.annotation.BinderThread",
+        "android.support.annotation.AnyThread",
+    ]
+
+    # If the annotation is on the class than it applies to every method
+    for a in clazz.annotations:
+        if repr(a) in THREADING_ANNOTATIONS:
+            return []
+
+    # Otherwise check all methods
+    methods = []
+    for f in clazz.methods:
+        has_annotation = False
+        for a in f.annotations:
+            if repr(a) in THREADING_ANNOTATIONS:
+                has_annotation = True
+        if not has_annotation:
+            error(clazz, f, "GV3", "Method missing threading annotation. Needs "
+                "one of: @MainThread, @UiThread, @WorkerThread, @BinderThread, "
+                "@AnyThread.")
+
 def verify_fields(clazz):
     """Verify that all exposed fields are final.
     Exposed fields must follow myName style.
@@ -1418,6 +1444,7 @@ def examine_clazz(clazz):
     verify_icu(clazz)
     verify_clone(clazz)
     verify_final_fields_only_class(clazz)
+    verify_threading_annotations(clazz)
 
 
 def examine_stream(stream):

--- a/apilint/src/test/resources/apilint_test.py
+++ b/apilint/src/test/resources/apilint_test.py
@@ -40,7 +40,9 @@ for t in tests:
     json_file = "{}/{}-result.json".format(args.build_dir, t["test"])
     test = ["python", "src/main/resources/apilint.py",
             "--result-json", json_file,
-            after_api, before_api, "--show-noticed"]
+            after_api, before_api,
+            "--filter-errors", t["filter"] if "filter" in t else "NONE",
+            "--show-noticed"]
 
     error_code = sp.call(test)
 

--- a/apilint/src/test/resources/apilint_test/tests.py
+++ b/apilint/src/test/resources/apilint_test/tests.py
@@ -71,10 +71,12 @@
   },{
     "test": "test-fields-only-class",
     "expected": "API_ERROR",
+    "filter": "GV",
     "rule": "GV1"
   },{
     "test": "test-fields-only-class-final",
     "expected": "API_ERROR",
+    "filter": "GV",
     "rule": "GV2"
   },{
     "test": "test-whitespace-change",


### PR DESCRIPTION
This adds some plumbing to enforce annotations with a lint:

- Includes parent classes annotations into the api (e.g. adds `@UiThread` to any class that extends `View`)
- Adds a lint to make sure one threading annotation is present either on the class or on each method
- Adds a way to filter errors so tests can be more focused (in the future this will be exposed to the plugin too).