### PR TITLE
Issue #34: Add a way to enforce specific lints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ apiLint {
     currentApiRelativeFilePath = 'api.txt'
     jsonResultFileName = 'apilint-result.json'
     changelogFileName = null
+    lintFilters = null
 }
 ```
 
@@ -122,3 +123,7 @@ contains the result of apilint.
 
 <code><b>changelogFileName</b></code> Relative path to the changelog file,
 optional. See also [Changelog](#changelog).
+
+<code><b>lintFilters</b></code> List of lints that fail the build, by default
+all lints can fail the build. Filters will match any error code that starts
+with the string specified, e.g. `GV` will match `GV1`, `GV2`, ...

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPluginExtension.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPluginExtension.groovy
@@ -8,4 +8,5 @@ class ApiLintPluginExtension {
     String currentApiRelativeFilePath = 'api.txt'
     String jsonResultFileName = 'apilint-result.json'
     String changelogFileName
+    List<String> lintFilters
 }

--- a/apilint/src/main/resources/apilint.py
+++ b/apilint/src/main/resources/apilint.py
@@ -1651,7 +1651,8 @@ if __name__ == "__main__":
                 filtered_fail[p] = cur_fail[p]
         cur_fail = filtered_fail
 
-    dump_result_json(args, compat_fail, cur_noticed, cur_fail)
+    dump_result_json(args, compat_fail,
+        cur_noticed if args['show_noticed'] else [], cur_fail)
 
     if compat_fail and len(compat_fail) != 0:
         print("%s API compatibility issues %s\n" % ((format(fg=WHITE, bg=BLUE, bold=True), format(reset=True))))


### PR DESCRIPTION
Before this commits no lints would actually fail the build because we only
checked for compatibility.

After this commit apilint runs the lint twice:

- Once with only the existing api as argument to check for lints (with an
  optional filter for lints).

- Once with both existing and new API to check for compatibility.

This adds a new configuration: `apiLint.lintFilters` which allows consumers to
set a list of prefixes of lints that can fail the build.