### PR TITLE
Fixes #47: Add skipClassesRegex to ignore specific classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ apiLint {
     apiOutputFileName = 'api.txt'
     currentApiRelativeFilePath = 'api.txt'
     jsonResultFileName = 'apilint-result.json'
+    skipClassesRegex = []
     changelogFileName = null
     lintFilters = null
 }
@@ -120,6 +121,11 @@ the source folder.
 
 <code><b>jsonResultFileName</b></code> Relative path to the JSON file name that
 contains the result of apilint.
+
+<code><b>skipClassesRegex</b></code> Apilint will ignore any class which full
+path matches any regex contained in this array. E.g. `BuildConfig$` whill match
+any class named `BuildConfig`, `^org.mozilla` will match any class in the
+package `org.mozilla`.
 
 <code><b>changelogFileName</b></code> Relative path to the changelog file,
 optional. See also [Changelog](#changelog).

--- a/apidoc-plugin/src/test/fake_root/org/mozilla/test/TestClass.java
+++ b/apidoc-plugin/src/test/fake_root/org/mozilla/test/TestClass.java
@@ -41,6 +41,9 @@ public class TestClass {
     }
     public static class TestExtends extends TestInterfaceImpl {}
 
+    public static class TestSkippedClass {}
+    public static class TestSkippedClass2 {}
+
     @Deprecated
     public static class TestAnnotationBase {
         private TestAnnotationBase() {}

--- a/apidoc-plugin/src/test/resources/apidoc_test.py
+++ b/apidoc-plugin/src/test/resources/apidoc_test.py
@@ -24,6 +24,8 @@ sp.check_call([args.javadoc,
     "-docletpath", args.doclet_jar,
     "-subpackages", "org.mozilla.test",
     "-sourcepath", args.java_root,
+    "-skip-class-regex", "TestSkippedClass$",
+    "-skip-class-regex", "^org.mozilla.test.TestClass.TestSkippedClass2$",
     "-output", output
 ])
 

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
@@ -18,8 +18,11 @@ class ApiCompatLintTask extends Javadoc {
     @Input
     String packageFilter
 
+    @Input
+    List<String> skipClasses
+
     @InputFiles
-    ArrayList<File> sourcePath
+    List<File> sourcePath
 
     private final static String CONFIG_NAME = 'apidoc-plugin'
 
@@ -45,6 +48,10 @@ class ApiCompatLintTask extends Javadoc {
         options.addStringOption('output', outputFile.absolutePath)
         options.addStringOption('subpackages', packageFilter)
         options.addStringOption('sourcepath', sourcePath.join(':'))
+
+        skipClassesRegex.each{ className ->
+                options.addStringOption('skip-class-regex', className)
+        }
 
         super.generate()
     }

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPlugin.groovy
@@ -35,10 +35,11 @@ class ApiLintPlugin implements Plugin<Project> {
                 }
 
                 source = variant.getJavaCompile().source
-                exclude '**/R.java', '**/BuildConfig.java'
+                exclude '**/R.java'
 
                 outputFile = apiFile
                 packageFilter = extension.packageFilter
+                skipClassesRegex = extension.skipClassesRegex
                 destinationDir = new File(destinationDir, variant.baseName)
                 sourcePath = variant.sourceSets.collect({ it.javaDirectories }).flatten()
             }

--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPluginExtension.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiLintPluginExtension.groovy
@@ -7,6 +7,8 @@ class ApiLintPluginExtension {
     String apiOutputFileName = 'api.txt'
     String currentApiRelativeFilePath = 'api.txt'
     String jsonResultFileName = 'apilint-result.json'
+    List<String> skipClassesRegex = []
+
     String changelogFileName
     List<String> lintFilters
 }


### PR DESCRIPTION
This adds a new extension `skipClassesRegex` which allows consumers to skip
classes from the API.

A common use for this is to skip `BuildConfig` as it's not really part of the
API.