### PR TITLE
Allow functional interfaces without default impls.

### DIFF
--- a/apilint/src/main/resources/apilint.py
+++ b/apilint/src/main/resources/apilint.py
@@ -602,6 +602,11 @@ def verify_default_impl(clazz):
     if "interface" not in clazz.split:
         return
 
+    if len(clazz.methods) == 1:
+        # Interfaces with just one method are "functional interfaces" and need
+        # to be abstract
+        return
+
     for f in clazz.methods:
         if "default" not in f.split:
             error(clazz, f, "GV6", "All interface methods should have a default "

--- a/apilint/src/test/resources/apilint_test/test-interface-default-functional.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-interface-default-functional.after.txt
@@ -1,0 +1,6 @@
+package test {
+  public interface FunctionalInterface {
+    method @android.support.annotation.UiThread public void testFunctional();
+  }
+}
+

--- a/apilint/src/test/resources/apilint_test/test-interface-default-functional.before.txt
+++ b/apilint/src/test/resources/apilint_test/test-interface-default-functional.before.txt
@@ -1,0 +1,3 @@
+package test {
+}
+

--- a/apilint/src/test/resources/apilint_test/test-interface-default-pass.after.txt
+++ b/apilint/src/test/resources/apilint_test/test-interface-default-pass.after.txt
@@ -1,6 +1,7 @@
 package test {
   public interface TestClass {
     method @android.support.annotation.UiThread public default void testMethod();
+    method @android.support.annotation.UiThread public default void testMethod2();
   }
 }
 

--- a/apilint/src/test/resources/apilint_test/tests.json
+++ b/apilint/src/test/resources/apilint_test/tests.json
@@ -72,6 +72,9 @@
     "test": "test-interface-default-pass",
     "expected": "API_CHANGE"
   },{
+    "test": "test-interface-default-functional",
+    "expected": "API_CHANGE"
+  },{
     "test": "test-fields-only-class",
     "expected": "API_ERROR",
     "check_compat": false,


### PR DESCRIPTION
Only interfaces without default impls are considered "functional interfaces",
so we can't have default impls for those interfaces.