### PR TITLE
Don't use ':' as path separator

### DIFF
--- a/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
+++ b/apilint/src/main/groovy/org/mozilla/apilint/ApiCompatLintTask.groovy
@@ -50,7 +50,7 @@ class ApiCompatLintTask extends Javadoc {
 
         options.addStringOption('output', outputFile.absolutePath)
         options.addStringOption('subpackages', packageFilter)
-        options.addPathOption('sourcepath', ':').setValue(sourcePath)
+        options.addPathOption('sourcepath').setValue(sourcePath)
         options.addStringOption('root-dir', rootDir)
         options.addStringOption('skip-class-regex', String.join(":", skipClassesRegex))
 


### PR DESCRIPTION
I think that apilint gradle plugin has https://bugzilla.mozilla.org/show_bug.cgi?id=1877157 too.

We shouldn't use ":" as path separator directly. Windows's is ';". So this should be omitted.