### PR TITLE
Improve parsing map text for Windows

### DIFF
--- a/apilint/src/main/resources/apilint.py
+++ b/apilint/src/main/resources/apilint.py
@@ -497,8 +497,8 @@ def read_map(api_map, lineNumber):
     mapString = api_map[lineNumber-1].strip()
     if not mapString:
         return Location("api.txt", lineNumber, 0)
-    [fileName,line,column] = mapString.split(":")
-    return Location(fileName, line, column)
+    m = re.match(r"(.*?):(\d+):(\d+)$", mapString)
+    return Location(m.group(1), m.group(2), m.group(3))
 
 failures = {}
 


### PR DESCRIPTION
*.txt.map format is `<absolute path>:<line number>:<column>`. `":"`  is used by separator for driver letter and path on Windows. So I would like to improve parsing this for Windows.

Also, unit test uses relative path, so I cannot add a unit test for this issue.